### PR TITLE
Display TimeFormat with abbreviated units using alternate flag

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,6 +114,10 @@ impl<T: Borrow<Duration>> TimeAsFloat for T {
 /// * `secs > 0.000_001` => microseconds with precision 3
 /// * otherwise => nanoseconds
 ///
+/// If the the format string is specified with the [alternate flag] `{:#}`,
+/// the duration is formatted using abbreviated units instead (e.g. "ms"
+/// instead of "milliseconds").
+///
 /// # Examples
 ///
 /// ```
@@ -123,9 +127,12 @@ impl<T: Borrow<Duration>> TimeAsFloat for T {
 /// let dur = Duration::new(0, 461_933);
 /// let formatted = format!("{}", TimeFormat(dur));
 /// assert_eq!(formatted, "461.933 microseconds");
+/// let alternate = format!("{:#}", TimeFormat(dur));
+/// assert_eq!(alternate, "461.933µs");
 /// ```
-///
+/// 
 /// [`Display`]: https://doc.rust-lang.org/stable/std/fmt/trait.Display.html
+/// [alternate flag]: https://doc.rust-lang.org/stable/std/fmt/#sign0
 #[derive(Clone, Copy, Debug)]
 pub struct TimeFormat<T: Borrow<Duration>>(pub T);
 
@@ -134,13 +141,29 @@ impl<T: Borrow<Duration>> Display for TimeFormat<T> {
         let dur: &Duration = self.0.borrow();
 
         if dur.as_secs() > 0 {
-            write!(f, "{:.3} seconds", dur.as_fractional_secs())
+            if f.alternate() {
+                write!(f, "{:.3}s", dur.as_fractional_secs())
+            } else {
+                write!(f, "{:.3} seconds", dur.as_fractional_secs())
+            }
         } else if dur.subsec_nanos() > 1_000_000 {
-            write!(f, "{:.3} milliseconds", dur.as_fractional_millis())
+            if f.alternate() {
+                write!(f, "{:.3}ms", dur.as_fractional_millis())
+            } else {
+                write!(f, "{:.3} milliseconds", dur.as_fractional_millis())
+            }
         } else if dur.subsec_nanos() > 1_000 {
-            write!(f, "{:.3} microseconds", dur.as_fractional_micros())
+            if f.alternate() {
+                write!(f, "{:.3}µs", dur.as_fractional_micros())
+            } else {
+                write!(f, "{:.3} microseconds", dur.as_fractional_micros())
+            }
         } else {
-            write!(f, "{} nanoseconds", dur.subsec_nanos())
+            if f.alternate() {
+                write!(f, "{}ns", dur.subsec_nanos())
+            } else {
+                write!(f, "{} nanoseconds", dur.subsec_nanos())
+            }
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,7 @@
 //! # }
 //! ```
 //!
-//! Output: `Needed 12.841 microseconds`
+//! Output: `Needed 12.841µs`
 //!
 //! [`Duration`]: https://doc.rust-lang.org/stable/std/time/struct.Duration.html
 //! [seconds]: trait.TimeAsFloat.html#tymethod.as_fractional_secs
@@ -114,9 +114,11 @@ impl<T: Borrow<Duration>> TimeAsFloat for T {
 /// * `secs > 0.000_001` => microseconds with precision 3
 /// * otherwise => nanoseconds
 ///
+/// By default the duration is formatted using abbreviated units
+/// (e.g. `1.234ms`).
 /// If the the format string is specified with the [alternate flag] `{:#}`,
-/// the duration is formatted using abbreviated units instead (e.g. "ms"
-/// instead of "milliseconds").
+/// the duration is formatted using the full unit name instead
+/// (e.g. `1.234 milliseconds`).
 ///
 /// # Examples
 ///
@@ -126,11 +128,11 @@ impl<T: Borrow<Duration>> TimeAsFloat for T {
 ///
 /// let dur = Duration::new(0, 461_933);
 /// let formatted = format!("{}", TimeFormat(dur));
-/// assert_eq!(formatted, "461.933 microseconds");
+/// assert_eq!(formatted, "461.933µs");
 /// let alternate = format!("{:#}", TimeFormat(dur));
-/// assert_eq!(alternate, "461.933µs");
+/// assert_eq!(alternate, "461.933 microseconds");
 /// ```
-/// 
+///
 /// [`Display`]: https://doc.rust-lang.org/stable/std/fmt/trait.Display.html
 /// [alternate flag]: https://doc.rust-lang.org/stable/std/fmt/#sign0
 #[derive(Clone, Copy, Debug)]
@@ -141,25 +143,25 @@ impl<T: Borrow<Duration>> Display for TimeFormat<T> {
         let dur: &Duration = self.0.borrow();
 
         if dur.as_secs() > 0 {
-            if f.alternate() {
+            if !f.alternate() {
                 write!(f, "{:.3}s", dur.as_fractional_secs())
             } else {
                 write!(f, "{:.3} seconds", dur.as_fractional_secs())
             }
         } else if dur.subsec_nanos() > 1_000_000 {
-            if f.alternate() {
+            if !f.alternate() {
                 write!(f, "{:.3}ms", dur.as_fractional_millis())
             } else {
                 write!(f, "{:.3} milliseconds", dur.as_fractional_millis())
             }
         } else if dur.subsec_nanos() > 1_000 {
-            if f.alternate() {
+            if !f.alternate() {
                 write!(f, "{:.3}µs", dur.as_fractional_micros())
             } else {
                 write!(f, "{:.3} microseconds", dur.as_fractional_micros())
             }
         } else {
-            if f.alternate() {
+            if !f.alternate() {
                 write!(f, "{}ns", dur.subsec_nanos())
             } else {
                 write!(f, "{} nanoseconds", dur.subsec_nanos())


### PR DESCRIPTION
First of all, thank you for this cool utility crate.

I wanted a method of displaying a TimeFormat in a more abbreviated way (e.g. using "ms" instead of "milliseconds").  So I implemented this by using the alternate flag {:#}.  Please feel free to include this if you think it might be useful.  It could also be implemented by e.g. using a different wrapper like TimeFormatAbbrev for the abbreviated format, but I thought this approach was the most unobtrusive way of adding this feature.